### PR TITLE
Fix ESLint on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,9 @@ jobs:
           name: run RuboCop
           command: bundle exec rubocop
 
-      # TO FIX
-      # - run:
-      #    name: run ESLint
-      #    command: ./node_modules/eslint/bin/eslint.js .
+      - run:
+          name: run ESLint
+          command: ./node_modules/eslint/bin/eslint.js
 
       # Deploy
       - deploy:

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,7 @@
 /config
 babel.config.js
 package.json
+**/*.rb
+**/*.json
+**/*.yml
+


### PR DESCRIPTION
## Description
* Enable ESLint on CircleCI
* Add all .rb .yml and .json files to .eslintignore

## Motivation and Context
* We encountered some problems with current ESLint configuration, which caused CircleCI process to crush when it reached "run ESLint" task. Probable cause was that it was trying to lint files that was previously checked by RuboCop and also .yml and .json files. After the changes, CircleCI process ends with success.

## Story
https://trello.com/c/8NXVBczb
