### PR TITLE
Add capistrano copy_files and copy node_modules between releases to speed up deployment

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -40,3 +40,6 @@ Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
 
 require 'capistrano/honeybadger'
 require 'whenever/capistrano'
+
+# https://github.com/capistrano/copy-files
+require 'capistrano/copy_files'

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :development do
   gem 'capistrano-rails', '~> 1.3', require: false
   gem 'capistrano-bundler'
   gem 'capistrano-rbenv'
+  gem 'capistrano-copy-files'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
       sshkit (>= 1.9.0)
     capistrano-bundler (1.6.0)
       capistrano (~> 3.1)
+    capistrano-copy-files (0.0.1)
+      capistrano (>= 3.0.0)
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -400,6 +402,7 @@ DEPENDENCIES
   byebug
   capistrano (~> 3.10)
   capistrano-bundler
+  capistrano-copy-files
   capistrano-rails (~> 1.3)
   capistrano-rbenv
   capybara (>= 2.15)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,6 +13,8 @@ set :rbenv_ruby, '2.6.5'
 
 set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 
+set :copy_files, ['node_modules']
+
 append :linked_dirs,
        'public/assets',
        'log',


### PR DESCRIPTION
# Description
Deploy takes ~17 min due to slow npm install taking a lot of time.

## Motivation and Context
https://github.com/capistrano/npm/issues/7

## Story
https://trello.com/c/p7WJugso/154-speed-up-deployment

# After testing it won't help

I did deploy after this improvement and it won't help.
Deploy took 10min.

~9min was spend in step `00:19 deploy:assets:precompile` where npm install was fast a few seconds but below step took ~9min

```
Compiling...
      01 Compiled all packs in /home/smogalert/application/releases/20200204173451/public…
      01
```

It looks like just a compilation of all our assets is crazy slow. This PR won't help with this.
